### PR TITLE
Add configurable arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ higher, is installed on your system. To install `rufo`, do the following:
 If you're are using [RVM](http://rvm.io) or [rbenv](https://github.com/rbenv/rbenv), seek
 for more information below.
 
+If you are using Windows, please use the settings [below](#on-windows).
+
 ## Settings
 
 You can configure vscode-rufo in your workspace or user settings. You can either
@@ -38,11 +40,16 @@ b) Manually adjust your settings via your `settings.json` file:
 {
   ...
   "rufo.exe": "rufo",  // can be an absolute path
+  "rufo.args": [],
   "rufo.useBundler": false,
 }
 ```
 
 *Attention:* Restart Visual Studio Code after you have made changes to the settings.
+
+### *On Windows:*
+ - `"rufo.exe": "cmd"`
+ - `"rufo.args": ["/c", "rufo.bat"]`
 
 ### Using RVM
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,12 @@
                     "description": "Path to invoke rufo",
                     "scope": "application"
                 },
+                "rufo.args": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Additional arguments to pass to the executable",
+                    "scope": "application"
+                },
                 "rufo.useBundler": {
                     "type": "boolean",
                     "default": false,

--- a/src/formatter/rufo.ts
+++ b/src/formatter/rufo.ts
@@ -3,11 +3,13 @@ import * as vscode from 'vscode';
 
 type RufoOptions = {
   exe: string,
+  args: string[],
   useBundler: boolean
 };
 
 const DEFAULT_OPTIONS: RufoOptions = {
   exe: "rufo",
+  args: [],
   useBundler: false
 };
 
@@ -107,8 +109,8 @@ export default class Rufo {
   }
 
   private get exe(): string[] {
-    const {exe, useBundler} = this.options;
-    return useBundler ? [`bundle exec ${exe}`] : [exe];
+    const {exe, args, useBundler} = this.options;
+    return useBundler ? [`bundle exec ${exe}`, ...args] : [exe, ...args];
   }
 
   private get options(): RufoOptions {


### PR DESCRIPTION
I created this fix because this extension did not work on my OS (Windows 10).

This would allow you to add custom arguments, making the command `cmd /c rufo.bat` possible to use with the extension.
To my knowledge, this was not possible (or quite annoying to set up) before.

resolves #5
I am also working on a better fix specifically for the OS issue, however that is not my priority. Maybe some day