### PR TITLE
fix invalid byte sequence by forcing UTF-8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3' # Not needed with a .ruby-version, .tool-versions or mise.toml
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Install rufo
+      run: gem install rufo
+    - name: Install Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 18.x
+    - run: npm install
+    - run: xvfb-run -a npm test
+      if: runner.os == 'Linux'
+    - run: npm test
+      if: runner.os != 'Linux'

--- a/src/formatter/rufo.ts
+++ b/src/formatter/rufo.ts
@@ -128,7 +128,7 @@ export default class Rufo {
 
     if (!spawnOpt.env) {
       // also here we need to assume UTF-8 (see above)
-      spawnOpt.env = { ...process.env, LANG: "en_US.UTF-8" }; // eslint-disable-line @typescript-eslint/naming-convention
+      spawnOpt.env = { ...process.env, LANG: "C.UTF-8" }; // eslint-disable-line @typescript-eslint/naming-convention
     }
 
     const cmd = exe.shift() as string;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -73,5 +73,5 @@ end`;
       .then(() => {
         assert.strictEqual(document.getText(), PARTIALLY);
       });
-  });
+  }).timeout(20000);
 });


### PR DESCRIPTION
fixes #7

also adds github actions for automated testing

Setting `LANG=en_US.UTF-8` results in the encoding `US-ASCII`, which causes issues with non-ASCII characters like `你好`.
Switching to `LANG=C.UTF-8` correctly sets the encoding to `UTF-8`, resolving the issue.